### PR TITLE
fix installation issue - remove bin script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "2.0.0",
   "description": "leveldb strong and eventual master-master replication",
   "main": "index.js",
-  "bin": {
-    "level-replicator": "./bin/server.js"
-  },
   "scripts": {
     "test": "mocha --recursive test --bail --colors --debug --timeout 4000"
   },


### PR DESCRIPTION
Fix this installation issue on npm 3:

```
npm ERR! Darwin 15.0.0
npm ERR! argv "node" "/usr/local/bin/npm" "i" "level-replicator" "--save"
npm ERR! node v0.12.7
npm ERR! npm  v3.3.3
npm ERR! path /Users/jose/Projects/oss/limitd/node_modules/level-replicator/bin/server.js
npm ERR! code ENOENT
npm ERR! errno -2

npm ERR! enoent ENOENT, chmod '/Users/jose/Projects/oss/limitd/node_modules/level-replicator/bin/server.js'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/jose/Projects/oss/limitd/npm-debug.log
```

Since this module doesn't have a `bin/server.js`.