### PR TITLE
do not read logs that the peer has gathered for current node

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,11 +165,12 @@ module.exports = function replicator(db, options) {
       }).on('error', function(err) {
         error = err;
       }).on('data', function(id) {
+        var peerId = id.replace(sublevels.peers, '');
         // we dont need to read logs that the peer has
         // gathered from us, that would be a waste of time.
-        if (id == instance_id) return;
+        if (peerId == instance_id) return;
         // push just the id into the array.
-        peers.push(id.replace(sublevels.peers, ''));
+        peers.push(peerId);
       }).on('end', function() {
         if (error) return cb(error);
         cb(null, peers);


### PR DESCRIPTION
The `replace` should be done before check if the id is equals to the current instance_id, otherwise it will never match.